### PR TITLE
Use `cross-env` for better compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "dist/index.esm.js",
   "scripts": {
     "all": "run-s lint test bundle test:integration",
-    "bundle": "NODE_ENV=production rollup -c",
+    "bundle": "cross-env NODE_ENV=production rollup -c",
     "lint": "eslint .",
     "test": "mocha -r esm test/*.spec.js",
     "test:integration": "mocha test/integration/*.spec.js",
@@ -28,6 +28,7 @@
     "babel-core": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "chai": "^4.1.2",
+    "cross-env": "^5.2.0",
     "eslint": "^5.6.1",
     "eslint-plugin-bpmn-io": "^0.6.0",
     "esm": "^3.0.84",


### PR DESCRIPTION
To fix the problem when running `yarn` in Windows:

```
$ NODE_ENV=production rollup -c
'NODE_ENV' 不是内部或外部命令，也不是可运行的程序
或批处理文件。
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
ERROR: "bundle" exited with 1.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```