### PR TITLE
Fix type declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ ___Note:__ Yet to be released changes appear here._
 
 ## 9.0.0
 
+_Migrates the code base to ES2018._
+
 * `FIX`: do not alter input in `annotate`
 * `CHORE`: migrate codebase to ES2018
 * `CHORE`: drop `UMD` prebuilt distribution

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -80,7 +80,7 @@ export type ModuleDefinition = ModuleDeclaration;
 export class Injector {
   constructor(modules: ModuleDefinition[], parent?: InjectorContext);
   get<T>(name: string, strict?: boolean): T;
-  invoke<T>(func: (...args: unknown[]) => T, context: InjectionContext, locals: LocalsMap): T;
+  invoke<T>(func: (...args: any[]) => T, context?: InjectionContext, locals?: LocalsMap): T;
   instantiate<T>(Type: T): T;
   createChild(modules: ModuleDefinition[], forceNewInstances?: string[]): Injector;
   init(): void;

--- a/test/integration/ts.spec.ts
+++ b/test/integration/ts.spec.ts
@@ -189,4 +189,53 @@ describe('typed', function() {
 
   });
 
+
+  describe('#invoke', function() {
+
+    it('should invoke', function() {
+
+      // given
+      const injector = new Injector([
+        {
+          one: [ 'value', 1 ],
+          two: [ 'value', 2 ]
+        }
+      ]);
+
+      type Four = {
+        four: number;
+      };
+
+      type Five = {
+        five: number;
+      };
+
+      // when
+      // then
+      expect(injector.invoke((one, two) => {
+        return one + two;
+      })).to.eql(3);
+
+      expect(injector.invoke((one, two, three) => {
+        return one + two + three;
+      }, null, { three: 3 })).to.eql(6);
+
+      expect(injector.invoke(function(this: Four, one, two, three) {
+        return one + two + three + this.four;
+      }, { four: 4 }, { three: 3 })).to.eql(10);
+
+      const result = injector.invoke(function() : Five {
+
+        const five : Five = {
+          five: 5
+        };
+
+        return five;
+      });
+
+      expect(result.five).to.eql(5);
+    });
+
+  });
+
 });


### PR DESCRIPTION
`Injector#invoke` type declaration was changed to:

```javascript
invoke<T>(func: (...args: any[]) => T, context?: InjectionContext, locals?: LocalsMap): T;
```

__Which issue does this PR address?__

Closes #20 